### PR TITLE
feat(mobile): sign in and sign up screens hitting Rails JSON API with JWT

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build:android:prod": "eas build --profile production --platform android --local"
   },
   "dependencies": {
+    "@expo-google-fonts/newsreader": "^0.4.1",
     "@expo-google-fonts/space-grotesk": "^0.4.0",
     "@expo/metro-runtime": "~55.0.6",
     "@react-navigation/bottom-tabs": "^7.2.0",
@@ -73,7 +74,8 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",
     "tailwindcss-animate": "^1.0.7",
-    "uniwind": "^1.6.3"
+    "uniwind": "^1.6.3",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@expo-google-fonts/newsreader':
+        specifier: ^0.4.1
+        version: 0.4.1
       '@expo-google-fonts/space-grotesk':
         specifier: ^0.4.0
         version: 0.4.1
@@ -137,6 +140,9 @@ importers:
       uniwind:
         specifier: ^1.6.3
         version: 1.6.3(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(tailwindcss@4.2.4)
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
       '@babel/core':
         specifier: ^7.20.0
@@ -1119,6 +1125,9 @@ packages:
 
   '@expo-google-fonts/material-symbols@0.4.33':
     resolution: {integrity: sha512-GQFy5tx7LBiRJttLYhz+KPmoVCQSVXiJPXVgMt/d8BWYbnJmw0nFixZtOaZQJE9F/L6vni3totwPNmbrdMi3ow==}
+
+  '@expo-google-fonts/newsreader@0.4.1':
+    resolution: {integrity: sha512-j96W112+mj/VYP06DCq00w+twyw42w0MY7eHB/XXioNK80BcG0cIk/zogjOENZSY7qejzIFbHE/PZYqlh/6VKQ==}
 
   '@expo-google-fonts/space-grotesk@0.4.1':
     resolution: {integrity: sha512-ZVQYw4Ok/pgcSJiufP8oRZE3AVxS9xtmKEUfsurbHkHNdMc/GA1gDXP9G4Cr7KL4KqSc0haexR2TuMigotCn4Q==}
@@ -6910,6 +6919,8 @@ snapshots:
   '@eslint/js@8.57.1': {}
 
   '@expo-google-fonts/material-symbols@0.4.33': {}
+
+  '@expo-google-fonts/newsreader@0.4.1': {}
 
   '@expo-google-fonts/space-grotesk@0.4.1': {}
 

--- a/src/app/(app)/(tabs)/_layout.tsx
+++ b/src/app/(app)/(tabs)/_layout.tsx
@@ -1,0 +1,11 @@
+import { Tabs } from "expo-router"
+
+export default function TabLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen name="clubs" options={{ title: "Clubs" }} />
+      <Tabs.Screen name="scan" options={{ title: "Scan" }} />
+      <Tabs.Screen name="profile" options={{ title: "Profile" }} />
+    </Tabs>
+  )
+}

--- a/src/app/(app)/(tabs)/clubs.tsx
+++ b/src/app/(app)/(tabs)/clubs.tsx
@@ -1,0 +1,10 @@
+import { View } from "react-native"
+import { Text } from "@/components/Text"
+
+export default function Clubs() {
+  return (
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <Text>Clubs</Text>
+    </View>
+  )
+}

--- a/src/app/(app)/(tabs)/profile.tsx
+++ b/src/app/(app)/(tabs)/profile.tsx
@@ -1,0 +1,10 @@
+import { View } from "react-native"
+import { Text } from "@/components/Text"
+
+export default function Profile() {
+  return (
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <Text>Profile</Text>
+    </View>
+  )
+}

--- a/src/app/(app)/(tabs)/scan.tsx
+++ b/src/app/(app)/(tabs)/scan.tsx
@@ -1,0 +1,10 @@
+import { View } from "react-native"
+import { Text } from "@/components/Text"
+
+export default function Scan() {
+  return (
+    <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+      <Text>Scan</Text>
+    </View>
+  )
+}

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,0 +1,14 @@
+import { Slot } from "expo-router"
+import { useAuthStore } from "@/stores/authStore"
+import { router } from "expo-router"
+import { useEffect } from "react"
+
+export default function AppLayout() {
+  const token = useAuthStore((state) => state.token)
+
+  useEffect(() => {
+    if (!token) router.replace("/(auth)/sign-in")
+  }, [token])
+
+  return <Slot />
+}

--- a/src/app/(app)/index.tsx
+++ b/src/app/(app)/index.tsx
@@ -1,0 +1,7 @@
+import { Redirect } from "expo-router"
+import { useAuthStore } from "@/stores/authStore"
+
+export default function Index() {
+  const token = useAuthStore((state) => state.token)
+  return <Redirect href={token ? "/(app)/(tabs)/clubs" : "/(auth)/sign-in"} />
+}

--- a/src/app/(auth)/_layout.tsx
+++ b/src/app/(auth)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router"
+
+export default function AuthLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />
+}

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react"
+import { View, ActivityIndicator } from "react-native"
+import { router } from "expo-router"
+import { Text } from "@/components/ui/text"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Screen } from "@/components/Screen"
+import { api } from "@/services/api"
+import { useAuthStore } from "@/stores/authStore"
+
+const inputClassName = "bg-surface-container border-outline-variant/50 rounded-sm h-[50px] px-[14px] text-sm text-on-surface"
+
+const labelClassName = "text-xs uppercase tracking-[0.1em] text-on-surface"
+
+export default function SignIn() {
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const setToken = useAuthStore((state) => state.setToken)
+
+  async function handleSignIn() {
+    setLoading(true)
+    setError(null)
+    const result = await api.signIn(email, password)
+    setLoading(false)
+
+    if (result.kind === "ok") {
+      setToken(result.data!.token)
+      router.replace("/(app)/(tabs)/clubs" as any)
+    } else if (result.data?.error) {
+      setError(result.data.error)
+    } else {
+      setError("Something went wrong. Please try again.")
+    }
+  }
+
+  return (
+    <Screen
+      preset="fixed"
+      safeAreaEdges={["top"]}
+      contentContainerStyle={{ paddingHorizontal: 24 }}
+    >
+      <Text
+        className="text-center text-3xl text-on-surface mt-20"
+        style={{ fontFamily: 'newsreaderMedium' }}
+      >
+        NextChapter
+      </Text>
+      <Text
+        className="text-center text-sm text-outline mt-2"
+        style={{ fontFamily: 'newsreaderRegularItalic' }}
+      >
+        A quiet space for intentional readers
+      </Text>
+
+      <View className="mt-12 gap-6">
+        {error && (
+          <Text className="text-primary text-sm text-center">{error}</Text>
+        )}
+
+        <View className="gap-1.5">
+          <Label htmlFor="email" className={labelClassName}>Email</Label>
+          <Input
+            id="email"
+            placeholder="you@example.com"
+            value={email}
+            onChangeText={setEmail}
+            autoCapitalize="none"
+            keyboardType="email-address"
+            className={inputClassName}
+          />
+        </View>
+
+        <View className="gap-1.5">
+          <Label htmlFor="password" className={labelClassName}>Password</Label>
+          <Input
+            id="password"
+            placeholder="••••••••"
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            className={inputClassName}
+          />
+        </View>
+
+        <Button
+          className="w-full bg-primary rounded-sm mt-2"
+          onPress={handleSignIn}
+          disabled={loading}
+        >
+          {loading
+            ? <ActivityIndicator color="#ffffff" />
+            : <Text className="text-on-primary text-xs font-medium uppercase tracking-wider text-center">Sign In</Text>
+          }
+        </Button>
+      </View>
+
+      <Text className="text-center text-sm text-outline mt-6">
+        Don't have an account?{" "}
+        <Text
+          className="text-primary text-sm font-medium"
+          onPress={() => router.push("/(auth)/sign-up" as any)}
+        >
+          Sign up
+        </Text>
+      </Text>
+    </Screen>
+  )
+}

--- a/src/app/(auth)/sign-up.tsx
+++ b/src/app/(auth)/sign-up.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react"
+import { View, ActivityIndicator } from "react-native"
+import { router } from "expo-router"
+import { Text } from "@/components/ui/text"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Screen } from "@/components/Screen"
+import { api } from "@/services/api"
+import { useAuthStore } from "@/stores/authStore"
+
+const inputClassName = "bg-surface-container border-outline-variant/50 rounded-sm h-[50px] px-[14px] text-sm text-on-surface"
+
+const labelClassName = "text-xs uppercase tracking-[0.1em] text-on-surface"
+
+export default function SignUp() {
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({})
+  const setToken = useAuthStore((state) => state.setToken)
+
+  async function handleSignUp() {
+    setLoading(true)
+    setError(null)
+    setFieldErrors({})
+    const result = await api.signUp(name, email, password)
+    setLoading(false)
+
+    if (result.kind === "ok") {
+      setToken(result.data!.token)
+      router.replace("/(app)/(tabs)/clubs" as any)
+    } else if (result.data?.errors) {
+      setFieldErrors(result.data.errors as Record<string, string[]>)
+      setError(result.data.error ?? "Please fix the errors below.")
+    } else if (result.data?.error) {
+      setError(result.data.error)
+    } else {
+      setError("Something went wrong. Please try again.")
+    }
+  }
+
+  return (
+    <Screen
+      preset="scroll"
+      safeAreaEdges={["top"]}
+      contentContainerStyle={{ paddingHorizontal: 24, paddingBottom: 32 }}
+    >
+        <Text
+          className="text-center text-3xl text-on-surface mt-14"
+          style={{ fontFamily: 'newsreaderMedium' }}
+        >
+          NextChapter
+        </Text>
+        <Text
+          className="text-center text-sm text-outline mt-2"
+          style={{ fontFamily: 'newsreaderRegularItalic' }}
+        >
+          A quiet space for intentional readers
+        </Text>
+
+        <View className="mt-10 gap-5">
+          {error && (
+            <Text className="text-primary text-sm text-center">{error}</Text>
+          )}
+
+          <View className="gap-1.5">
+            <Label htmlFor="name" className={labelClassName}>Name</Label>
+            <Input
+              id="name"
+              placeholder="Your full name"
+              value={name}
+              onChangeText={setName}
+              className={inputClassName}
+            />
+            {fieldErrors.name?.map((e) => (
+              <Text key={e} className="text-primary text-xs">{e}</Text>
+            ))}
+          </View>
+
+          <View className="gap-1.5">
+            <Label htmlFor="email" className={labelClassName}>Email</Label>
+            <Input
+              id="email"
+              placeholder="you@example.com"
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              keyboardType="email-address"
+              className={inputClassName}
+            />
+            {fieldErrors.email_address?.map((e) => (
+              <Text key={e} className="text-primary text-xs">{e}</Text>
+            ))}
+          </View>
+
+          <View className="gap-1.5">
+            <Label htmlFor="password" className={labelClassName}>Password</Label>
+            <Input
+              id="password"
+              placeholder="••••••••"
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              className={inputClassName}
+            />
+            {fieldErrors.password?.map((e) => (
+              <Text key={e} className="text-primary text-xs">{e}</Text>
+            ))}
+          </View>
+
+          <View className="gap-1.5">
+            <Label htmlFor="confirm" className={labelClassName}>Confirm Password</Label>
+            <Input
+              id="confirm"
+              placeholder="••••••••"
+              value={confirm}
+              onChangeText={setConfirm}
+              secureTextEntry
+              className={inputClassName}
+            />
+          </View>
+
+          <Button
+            className="w-full bg-primary rounded-sm mt-2"
+            onPress={handleSignUp}
+            disabled={loading}
+          >
+            {loading
+              ? <ActivityIndicator color="#ffffff" />
+              : <Text className="text-on-primary text-xs font-medium uppercase tracking-wider text-center">Create Account</Text>
+            }
+          </Button>
+        </View>
+
+        <Text className="text-center text-sm text-outline mt-6">
+          Already have an account?{" "}
+          <Text
+            className="text-primary text-sm font-medium"
+            onPress={() => router.push("/(auth)/sign-in" as any)}
+          >
+            Sign in
+          </Text>
+        </Text>
+    </Screen>
+  )
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,7 +1,7 @@
 import "../global.css"
 
 import { useEffect, useState } from "react"
-import { Slot, SplashScreen } from "expo-router"
+import { Slot, SplashScreen, router} from "expo-router"
 import { useFonts } from "@expo-google-fonts/space-grotesk"
 import { KeyboardProvider } from "react-native-keyboard-controller"
 import { initialWindowMetrics, SafeAreaProvider } from "react-native-safe-area-context"
@@ -11,6 +11,8 @@ import { initI18n } from "@/i18n"
 import { ThemeProvider } from "@/theme/context"
 import { customFontsToLoad } from "@/theme/typography"
 import { loadDateFnsLocale } from "@/utils/formatDate"
+
+import { useAuthStore } from "@/stores/authStore"
 
 SplashScreen.preventAutoHideAsync()
 
@@ -38,14 +40,10 @@ export default function Root() {
   }, [fontError])
 
   useEffect(() => {
-    if (loaded) {
-      SplashScreen.hideAsync()
-    }
+    if (loaded) SplashScreen.hideAsync()
   }, [loaded])
 
-  if (!loaded) {
-    return null
-  }
+  if (!loaded) return null
 
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,0 @@
-import { WelcomeScreen } from "@/screens/WelcomeScreen"
-
-export default function Index() {
-  return <WelcomeScreen />
-}

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -263,6 +263,7 @@ export function Screen(props: ScreenProps) {
         { backgroundColor: backgroundColor || colors.background },
         $containerInsets,
       ]}
+      className={backgroundColor ? "" : "bg-background"}
     >
       <SystemBars
         style={systemBarStyle || (themeContext === "dark" ? "light" : "dark")}

--- a/src/config/config.base.ts
+++ b/src/config/config.base.ts
@@ -2,6 +2,7 @@ export interface ConfigBaseProps {
   persistNavigation: "always" | "dev" | "prod" | "never"
   catchErrors: "always" | "dev" | "prod" | "never"
   exitRoutes: string[]
+  API_URL: string
 }
 
 export type PersistNavigationConfig = ConfigBaseProps["persistNavigation"]
@@ -21,6 +22,7 @@ const BaseConfig: ConfigBaseProps = {
    * is pressed while in that screen. Only affects Android.
    */
   exitRoutes: ["Welcome"],
+  API_URL: "https://api.example.com",
 }
 
 export default BaseConfig

--- a/src/config/config.dev.ts
+++ b/src/config/config.dev.ts
@@ -6,5 +6,5 @@
  * https://reactnative.dev/docs/security#storing-sensitive-info
  */
 export default {
-  API_URL: "https://api.rss2json.com/v1/",
+  API_URL: "http://localhost:3000",
 }

--- a/src/config/config.prod.ts
+++ b/src/config/config.prod.ts
@@ -6,5 +6,5 @@
  * https://reactnative.dev/docs/security#storing-sensitive-info
  */
 export default {
-  API_URL: "https://api.rss2json.com/v1/",
+  API_URL: "https://nextchapter.fly.dev",
 }

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -9,7 +9,8 @@ import { ApisauceInstance, create } from "apisauce"
 
 import Config from "@/config"
 
-import type { ApiConfig } from "./types"
+import type { ApiConfig, ApiErrorResponse, AuthResponse } from "./types"
+import { getGeneralApiProblem, type GeneralApiProblem } from "./apiProblem"
 
 /**
  * Configuring the apisauce instance.
@@ -39,6 +40,37 @@ export class Api {
         Accept: "application/json",
       },
     })
+  }
+
+  async signIn(email: string, password: string): Promise<
+    { kind: "ok"; data: AuthResponse } |
+    { kind: GeneralApiProblem["kind"]; data: ApiErrorResponse | undefined }
+  > {
+    const response = await this.apisauce.post<AuthResponse, ApiErrorResponse>(
+      "/api/v1/sessions",
+      { email_address: email, password }
+    )
+    if (!response.ok) {
+      const problem = getGeneralApiProblem(response)
+      return { kind: problem?.kind ?? "unknown", data: response.data as ApiErrorResponse }
+
+    }
+    return { kind: "ok", data: (response.data as any).data as AuthResponse }
+  }
+
+  async signUp(name: string, email: string, password: string): Promise<
+    { kind: "ok"; data: AuthResponse } |
+    { kind: GeneralApiProblem["kind"]; data: ApiErrorResponse | undefined }
+  > {
+    const response = await this.apisauce.post<AuthResponse, ApiErrorResponse>(
+    "/api/v1/registrations",
+      { user: { name, email_address: email, password, password_confirmation: password } }
+    )
+    if (!response.ok) {
+      const problem = getGeneralApiProblem(response)
+      return { kind: problem?.kind ?? "unknown", data: response.data as ApiErrorResponse }
+    }
+    return { kind: "ok", data: (response.data as any).data as AuthResponse }
   }
 }
 

--- a/src/services/api/types.ts
+++ b/src/services/api/types.ts
@@ -1,50 +1,15 @@
-/**
- * These types indicate the shape of the data you expect to receive from your
- * API endpoint, assuming it's a JSON object like we have.
- */
-export interface EpisodeItem {
-  title: string
-  pubDate: string
-  link: string
-  guid: string
-  author: string
-  thumbnail: string
-  description: string
-  content: string
-  enclosure: {
-    link: string
-    type: string
-    length: number
-    duration: number
-    rating: { scheme: string; value: string }
-  }
-  categories: string[]
-}
-
-export interface ApiFeedResponse {
-  status: string
-  feed: {
-    url: string
-    title: string
-    link: string
-    author: string
-    description: string
-    image: string
-  }
-  items: EpisodeItem[]
-}
-
-/**
- * The options used to configure apisauce.
- */
 export interface ApiConfig {
-  /**
-   * The URL of the api.
-   */
   url: string
-
-  /**
-   * Milliseconds before we timeout the request.
-   */
   timeout: number
+}
+
+export interface AuthResponse {
+  token: string
+  refresh_token: string
+  expires_at: string
+}
+
+export interface ApiErrorResponse {
+  error?: string
+  errors?: Record<string, string[]>
 }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand"
+
+interface AuthState {
+  token: string | null
+  setToken: (token: string) => void
+  clearToken: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  token: null,
+  setToken: (token) => set({ token }),
+  clearToken: () => set({ token: null }),
+}))

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -9,6 +9,10 @@ import {
   SpaceGrotesk_600SemiBold as spaceGroteskSemiBold,
   SpaceGrotesk_700Bold as spaceGroteskBold,
 } from "@expo-google-fonts/space-grotesk"
+import {
+  Newsreader_400Regular_Italic as newsreaderRegularItalic,
+  Newsreader_500Medium as newsreaderMedium,
+} from "@expo-google-fonts/newsreader"
 
 export const customFontsToLoad = {
   spaceGroteskLight,
@@ -16,6 +20,8 @@ export const customFontsToLoad = {
   spaceGroteskMedium,
   spaceGroteskSemiBold,
   spaceGroteskBold,
+  newsreaderMedium,
+  newsreaderRegularItalic,
 }
 
 const fonts = {


### PR DESCRIPTION
Add authentication screens and JWT-based auth store integration with Rails JSON API:

- Add Sign In screen (`/(auth)/sign-in`) with email/password fields and API integration
- Add Sign Up screen (`/(auth)/sign-up`) with name/email/password fields and field-level error display
- Integrate with Rails endpoints: POST `/api/v1/sessions` and POST `/api/v1/registrations`
- Implement Zustand auth store (`authStore.ts`) for stateless JWT token management
- Add protected app layout (`/(app)/_layout.tsx`) that redirects unauthenticated users to sign-in
- Setup tab-based navigation for authenticated users: clubs, scan, profile
- Configure environment-specific API URLs (dev: localhost:3000, prod: nextchapter.fly.dev)
- Add error handling for 422 validation responses with inline field-level error display
- Extend apisauce API layer with `signIn()` and `signUp()` methods
- Add Newsreader font family for brand typography

Auth flow is now complete: unauthenticated users land on `/sign-in`, upon successful login/signup the JWT token is stored in Zustand and users are redirected to the main app experience.