### PR TITLE
feat(mobile): persist auth state with Expo SecureStore

### DIFF
--- a/app.json
+++ b/app.json
@@ -68,7 +68,8 @@
       }
     ],
     "expo-build-properties",
-    "expo-router"
+    "expo-router",
+    "expo-secure-store"
   ],
   "experiments": {
     "tsconfigPaths": true,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "expo-linking": "~55.0.7",
     "expo-localization": "~55.0.8",
     "expo-router": "~55.0.4",
+    "expo-secure-store": "~55.0.13",
     "expo-splash-screen": "~55.0.10",
     "expo-system-ui": "~55.0.9",
     "i18next": "^23.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       expo-router:
         specifier: ~55.0.4
         version: 55.0.13(9e93221444237d20a1a007b05a113d78)
+      expo-secure-store:
+        specifier: ~55.0.13
+        version: 55.0.13(expo@55.0.17)
       expo-splash-screen:
         specifier: ~55.0.10
         version: 55.0.19(expo@55.0.17)(typescript@5.9.3)
@@ -3240,6 +3243,11 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-secure-store@55.0.13:
+    resolution: {integrity: sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@55.0.8:
     resolution: {integrity: sha512-AoV5TKuO4biSzrhe/OVLyInfTT0pV9/OOc/g/oVq5vmCjL8SaSYTkES8PLt+67Tm7VqX+Dn0+kSx1nQcjEKaPw==}
@@ -9572,6 +9580,10 @@ snapshots:
       - '@types/react-dom'
       - expo-font
       - supports-color
+
+  expo-secure-store@55.0.13(expo@55.0.17):
+    dependencies:
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-server@55.0.8: {}
 

--- a/src/app/(app)/(tabs)/profile.tsx
+++ b/src/app/(app)/(tabs)/profile.tsx
@@ -1,10 +1,20 @@
 import { View } from "react-native"
+import { router } from "expo-router"
+import { Button } from "@/components/ui/button"
 import { Text } from "@/components/Text"
+import { useAuthStore } from "@/stores/authStore"
 
 export default function Profile() {
+  const clearToken = useAuthStore((state) => state.clearToken)
+
   return (
     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
-      <Text>Profile</Text>
+      <Button onPress={async () => {
+        await clearToken()
+        router.replace("/(auth)/sign-in" as any)
+      }}>
+        <Text>Sign Out</Text>
+      </Button>
     </View>
   )
 }

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -27,7 +27,7 @@ export default function SignIn() {
     setLoading(false)
 
     if (result.kind === "ok") {
-      setToken(result.data!.token)
+      await setToken(result.data!.token)
       router.replace("/(app)/(tabs)/clubs" as any)
     } else if (result.data?.error) {
       setError(result.data.error)

--- a/src/app/(auth)/sign-up.tsx
+++ b/src/app/(auth)/sign-up.tsx
@@ -31,7 +31,7 @@ export default function SignUp() {
     setLoading(false)
 
     if (result.kind === "ok") {
-      setToken(result.data!.token)
+      await setToken(result.data!.token)
       router.replace("/(app)/(tabs)/clubs" as any)
     } else if (result.data?.errors) {
       setFieldErrors(result.data.errors as Record<string, string[]>)

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -27,13 +27,22 @@ export default function Root() {
   const [fontsLoaded, fontError] = useFonts(customFontsToLoad)
   const [isI18nInitialized, setIsI18nInitialized] = useState(false)
 
+  const rehydrate = useAuthStore((state) => state.rehydrate)
+  const hydrated = useAuthStore((state) => state.hydrated)
+
+  useEffect(() => {
+    if (!hydrated) {
+      rehydrate()
+    }
+  }, [rehydrate, hydrated])
+
   useEffect(() => {
     initI18n()
       .then(() => setIsI18nInitialized(true))
       .then(() => loadDateFnsLocale())
   }, [])
 
-  const loaded = fontsLoaded && isI18nInitialized
+  const loaded = fontsLoaded && isI18nInitialized && hydrated
 
   useEffect(() => {
     if (fontError) throw fontError

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,13 +1,32 @@
 import { create } from "zustand"
+import * as SecureStore from "expo-secure-store"
+
+const TOKEN_KEY = "auth_token"
 
 interface AuthState {
   token: string | null
-  setToken: (token: string) => void
-  clearToken: () => void
+  hydrated: boolean
+  setToken: (token: string) => Promise<void>
+  clearToken: () => Promise<void>
+  rehydrate: () => Promise<void>
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   token: null,
-  setToken: (token) => set({ token }),
-  clearToken: () => set({ token: null }),
+  hydrated: false,
+
+  setToken: async (token) => {
+    await SecureStore.setItemAsync(TOKEN_KEY, token)
+    set({ token })
+  },
+
+  clearToken: async () => {
+    await SecureStore.deleteItemAsync(TOKEN_KEY)
+    set({ token: null })
+  },
+
+  rehydrate: async () => {
+    const token = await SecureStore.getItemAsync(TOKEN_KEY)
+    set({ token, hydrated: true })
+  },
 }))


### PR DESCRIPTION
Implement secure token storage and automatic state rehydration:

- Add expo-secure-store dependency for encrypted token persistence
- Update AuthStore with async setToken/clearToken methods for SecureStore integration
- Add rehydrate method to restore auth token on app startup
- Add hydrated flag to track store initialization state
- Integrate rehydration into root layout startup sequence
- Update auth screens to await async token storage operations
- Add sign-out functionality to profile screen with navigation back to sign-in

This ensures auth tokens are securely stored and automatically restored across app sessions.

Closes #4 
Closes #5 