### PR TITLE
refactor(mobile): split screens into dedicated screen and component files

### DIFF
--- a/src/app/(app)/(tabs)/clubs.tsx
+++ b/src/app/(app)/(tabs)/clubs.tsx
@@ -1,59 +1,11 @@
 import { useCallback, useEffect, useState } from "react"
-import {
-  ActivityIndicator,
-  FlatList,
-  RefreshControl,
-  StyleSheet,
-  TouchableOpacity,
-  View,
-} from "react-native"
 import { router } from "expo-router"
 
-import { Screen } from "@/components/Screen"
-import { StateBadge } from "@/components/StateBadge"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Text } from "@/components/ui/text"
+import { ClubsScreen } from "@/screens/ClubsScreen"
 import { api } from "@/services/api"
 import type { ClubSummary } from "@/services/api/types"
-import { useAppTheme } from "@/theme/context"
-
-function ClubCard({ club }: { club: ClubSummary }) {
-  const state = club.current_cycle?.state ?? null
-  return (
-    <TouchableOpacity activeOpacity={0.7} onPress={() => router.push(`/(app)/club/${club.id}`)}>
-      <Card className="mb-3 rounded border-0 bg-surface-container-lowest px-0 shadow-none gap-0">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-lg font-normal text-on-surface" style={styles.titleFont}>
-            {club.name}
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="gap-2">
-          {state ? <StateBadge state={state} /> : null}
-          {club.description ? (
-            <Text className="text-sm text-outline leading-relaxed">{club.description}</Text>
-          ) : null}
-        </CardContent>
-      </Card>
-    </TouchableOpacity>
-  )
-}
-
-function EmptyState() {
-  return (
-    <View className="items-center px-6 gap-3 mt-16">
-      <Text className="text-xl text-on-surface text-center" style={styles.titleFont}>
-        Your bookshelf is waiting.
-      </Text>
-      <Text className="text-sm text-outline text-center leading-relaxed">
-        Start or join a club to begin your next chapter.
-      </Text>
-    </View>
-  )
-}
 
 export default function Clubs() {
-  const { theme } = useAppTheme()
-  const colors = theme.colors
   const [clubs, setClubs] = useState<ClubSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -81,71 +33,13 @@ export default function Clubs() {
   }, [fetchClubs])
 
   return (
-    <Screen preset="fixed" safeAreaEdges={["top"]} contentContainerStyle={styles.screenContent}>
-      {loading ? (
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator color={colors.primary} />
-        </View>
-      ) : (
-        <FlatList
-          data={clubs}
-          keyExtractor={(item) => String(item.id)}
-          renderItem={({ item }) => <ClubCard club={item} />}
-          contentContainerStyle={styles.listContent}
-          ListHeaderComponent={
-            <Text
-              className="text-on-surface mt-12 mb-5 text-[28px] tracking-tight"
-              style={styles.titleFont}
-            >
-              Your Clubs
-            </Text>
-          }
-          ListEmptyComponent={
-            error ? (
-              <Text className="text-sm text-outline text-center mt-8">{error}</Text>
-            ) : (
-              <EmptyState />
-            )
-          }
-          /* Commenting until Write pass is in place */
-          // ListFooterComponent={
-          //   <View className="items-center mt-8 mb-4">
-          //     <TouchableOpacity
-          //       className="bg-primary rounded-sm px-7 py-3.5"
-          //       activeOpacity={0.8}
-          //     >
-          //       <Text
-          //         className="text-on-primary text-xs font-medium uppercase tracking-widest"
-          //         style={{ fontFamily: "workSansMedium" }}
-          //       >
-          //         Create a Club
-          //       </Text>
-          //     </TouchableOpacity>
-          //   </View>
-          // }
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => fetchClubs(true)}
-              tintColor={colors.primary}
-            />
-          }
-        />
-      )}
-    </Screen>
+    <ClubsScreen
+      clubs={clubs}
+      loading={loading}
+      refreshing={refreshing}
+      error={error}
+      onClubPress={(id) => router.push(`/(app)/club/${id}`)}
+      onRefresh={() => fetchClubs(true)}
+    />
   )
 }
-
-const styles = StyleSheet.create({
-  listContent: {
-    flexGrow: 1,
-    paddingBottom: 16,
-    paddingHorizontal: 20,
-  },
-  screenContent: {
-    flex: 1,
-  },
-  titleFont: {
-    fontFamily: "newsreaderRegular",
-  },
-})

--- a/src/app/(auth)/_layout.tsx
+++ b/src/app/(auth)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from "expo-router"
 
 export default function AuthLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />
+  return <Stack screenOptions={{ headerShown: false, animation: "fade" }} />
 }

--- a/src/app/(auth)/sign-in.tsx
+++ b/src/app/(auth)/sign-in.tsx
@@ -1,31 +1,16 @@
 import { useState } from "react"
-import { View, ActivityIndicator, StyleSheet } from "react-native"
 import { router } from "expo-router"
 
-import { Screen } from "@/components/Screen"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Text } from "@/components/ui/text"
+import { SignInScreen } from "@/screens/SignInScreen"
 import { api } from "@/services/api"
 import { useAuthStore } from "@/stores/authStore"
-import { useAppTheme } from "@/theme/context"
-
-const inputClassName =
-  "bg-surface-container border-outline-variant/50 rounded-sm h-[50px] px-[14px] text-sm text-on-surface"
-
-const labelClassName = "text-xs uppercase tracking-[0.1em] text-on-surface"
 
 export default function SignIn() {
-  const { theme } = useAppTheme()
-  const colors = theme.colors
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const setTokens = useAuthStore((state) => state.setTokens)
 
-  async function handleSignIn() {
+  async function handleSignIn(email: string, password: string) {
     setLoading(true)
     setError(null)
     const result = await api.signIn(email, password)
@@ -42,82 +27,11 @@ export default function SignIn() {
   }
 
   return (
-    <Screen preset="fixed" safeAreaEdges={["top"]} contentContainerStyle={styles.content}>
-      <Text className="text-center text-3xl text-on-surface mt-20" style={styles.titleFont}>
-        NextChapter
-      </Text>
-      <Text className="text-center text-sm text-outline mt-2" style={styles.subtitleFont}>
-        A quiet space for intentional readers
-      </Text>
-
-      <View className="mt-12 gap-6">
-        {error && <Text className="text-primary text-sm text-center">{error}</Text>}
-
-        <View className="gap-1.5">
-          <Label htmlFor="email" className={labelClassName}>
-            Email
-          </Label>
-          <Input
-            id="email"
-            placeholder="you@example.com"
-            value={email}
-            onChangeText={setEmail}
-            autoCapitalize="none"
-            keyboardType="email-address"
-            className={inputClassName}
-          />
-        </View>
-
-        <View className="gap-1.5">
-          <Label htmlFor="password" className={labelClassName}>
-            Password
-          </Label>
-          <Input
-            id="password"
-            placeholder="••••••••"
-            value={password}
-            onChangeText={setPassword}
-            secureTextEntry
-            className={inputClassName}
-          />
-        </View>
-
-        <Button
-          className="w-full bg-primary rounded-sm mt-2"
-          onPress={handleSignIn}
-          disabled={loading}
-        >
-          {loading ? (
-            <ActivityIndicator color={colors.onPrimary} />
-          ) : (
-            <Text className="text-on-primary text-xs font-medium uppercase tracking-wider text-center">
-              Sign In
-            </Text>
-          )}
-        </Button>
-      </View>
-
-      <Text className="text-center text-sm text-outline mt-6">
-        Don&apos;t have an account?{" "}
-        <Text
-          className="text-primary text-sm font-medium"
-          onPress={() => router.push("/(auth)/sign-up")}
-        >
-          Sign up
-        </Text>
-      </Text>
-    </Screen>
+    <SignInScreen
+      loading={loading}
+      error={error}
+      onSignIn={handleSignIn}
+      onSignUp={() => router.push("/(auth)/sign-up")}
+    />
   )
 }
-
-const styles = StyleSheet.create({
-  content: {
-    paddingHorizontal: 24,
-  },
-  subtitleFont: {
-    fontFamily: "newsreaderRegularItalic",
-  },
-  titleFont: {
-    fontFamily: "newsreaderMedium",
-  },
-})

--- a/src/app/(auth)/sign-up.tsx
+++ b/src/app/(auth)/sign-up.tsx
@@ -1,34 +1,17 @@
 import { useState } from "react"
-import { View, ActivityIndicator, StyleSheet } from "react-native"
 import { router } from "expo-router"
 
-import { Screen } from "@/components/Screen"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Text } from "@/components/ui/text"
+import { SignUpScreen } from "@/screens/SignUpScreen"
 import { api } from "@/services/api"
 import { useAuthStore } from "@/stores/authStore"
-import { useAppTheme } from "@/theme/context"
-
-const inputClassName =
-  "bg-surface-container border-outline-variant/50 rounded-sm h-[50px] px-[14px] text-sm text-on-surface"
-
-const labelClassName = "text-xs uppercase tracking-[0.1em] text-on-surface"
 
 export default function SignUp() {
-  const { theme } = useAppTheme()
-  const colors = theme.colors
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const [confirm, setConfirm] = useState("")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({})
   const setTokens = useAuthStore((state) => state.setTokens)
 
-  async function handleSignUp() {
+  async function handleSignUp(name: string, email: string, password: string) {
     setLoading(true)
     setError(null)
     setFieldErrors({})
@@ -49,125 +32,12 @@ export default function SignUp() {
   }
 
   return (
-    <Screen preset="scroll" safeAreaEdges={["top"]} contentContainerStyle={styles.content}>
-      <Text className="text-center text-3xl text-on-surface mt-14" style={styles.titleFont}>
-        NextChapter
-      </Text>
-      <Text className="text-center text-sm text-outline mt-2" style={styles.subtitleFont}>
-        A quiet space for intentional readers
-      </Text>
-
-      <View className="mt-10 gap-5">
-        {error && <Text className="text-primary text-sm text-center">{error}</Text>}
-
-        <View className="gap-1.5">
-          <Label htmlFor="name" className={labelClassName}>
-            Name
-          </Label>
-          <Input
-            id="name"
-            placeholder="Your full name"
-            value={name}
-            onChangeText={setName}
-            className={inputClassName}
-          />
-          {fieldErrors.name?.map((e) => (
-            <Text key={e} className="text-primary text-xs">
-              {e}
-            </Text>
-          ))}
-        </View>
-
-        <View className="gap-1.5">
-          <Label htmlFor="email" className={labelClassName}>
-            Email
-          </Label>
-          <Input
-            id="email"
-            placeholder="you@example.com"
-            value={email}
-            onChangeText={setEmail}
-            autoCapitalize="none"
-            keyboardType="email-address"
-            className={inputClassName}
-          />
-          {fieldErrors.email_address?.map((e) => (
-            <Text key={e} className="text-primary text-xs">
-              {e}
-            </Text>
-          ))}
-        </View>
-
-        <View className="gap-1.5">
-          <Label htmlFor="password" className={labelClassName}>
-            Password
-          </Label>
-          <Input
-            id="password"
-            placeholder="••••••••"
-            value={password}
-            onChangeText={setPassword}
-            secureTextEntry
-            className={inputClassName}
-          />
-          {fieldErrors.password?.map((e) => (
-            <Text key={e} className="text-primary text-xs">
-              {e}
-            </Text>
-          ))}
-        </View>
-
-        <View className="gap-1.5">
-          <Label htmlFor="confirm" className={labelClassName}>
-            Confirm Password
-          </Label>
-          <Input
-            id="confirm"
-            placeholder="••••••••"
-            value={confirm}
-            onChangeText={setConfirm}
-            secureTextEntry
-            className={inputClassName}
-          />
-        </View>
-
-        <Button
-          className="w-full bg-primary rounded-sm mt-2"
-          onPress={handleSignUp}
-          disabled={loading}
-        >
-          {loading ? (
-            <ActivityIndicator color={colors.onPrimary} />
-          ) : (
-            <Text className="text-on-primary text-xs font-medium uppercase tracking-wider text-center">
-              Create Account
-            </Text>
-          )}
-        </Button>
-      </View>
-
-      <Text className="text-center text-sm text-outline mt-6">
-        Already have an account?{" "}
-        <Text
-          className="text-primary text-sm font-medium"
-          onPress={() => router.push("/(auth)/sign-in")}
-        >
-          Sign in
-        </Text>
-      </Text>
-    </Screen>
+    <SignUpScreen
+      loading={loading}
+      error={error}
+      fieldErrors={fieldErrors}
+      onSignUp={handleSignUp}
+      onSignIn={() => router.push("/(auth)/sign-in")}
+    />
   )
 }
-
-const styles = StyleSheet.create({
-  content: {
-    paddingBottom: 32,
-    paddingHorizontal: 24,
-  },
-  subtitleFont: {
-    fontFamily: "newsreaderRegularItalic",
-  },
-  titleFont: {
-    fontFamily: "newsreaderMedium",
-  },
-})

--- a/src/components/Auth/AuthHeader.tsx
+++ b/src/components/Auth/AuthHeader.tsx
@@ -1,0 +1,36 @@
+import { StyleSheet } from "react-native"
+
+import { Text } from "@/components/ui/text"
+import { cn } from "@/lib/utils"
+
+type AuthHeaderProps = {
+  variant: "sign-in" | "sign-up"
+}
+
+export function AuthHeader({ variant }: AuthHeaderProps) {
+  return (
+    <>
+      <Text
+        className={cn(
+          "text-center text-3xl text-on-surface",
+          variant === "sign-in" ? "mt-20" : "mt-14",
+        )}
+        style={styles.titleFont}
+      >
+        NextChapter
+      </Text>
+      <Text className="text-center text-sm text-outline mt-2" style={styles.subtitleFont}>
+        A quiet space for intentional readers
+      </Text>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  subtitleFont: {
+    fontFamily: "newsreaderRegularItalic",
+  },
+  titleFont: {
+    fontFamily: "newsreaderMedium",
+  },
+})

--- a/src/components/Auth/SignInForm.tsx
+++ b/src/components/Auth/SignInForm.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react"
+import { View, ActivityIndicator } from "react-native"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Text } from "@/components/ui/text"
+import { useAppTheme } from "@/theme/context"
+
+import { inputClassName, labelClassName } from "./authFormStyles"
+
+type SignInFormProps = {
+  loading: boolean
+  error: string | null
+  onSubmit: (email: string, password: string) => void
+  onSignUp: () => void
+}
+
+export function SignInForm({ loading, error, onSubmit, onSignUp }: SignInFormProps) {
+  const { theme } = useAppTheme()
+  const colors = theme.colors
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+
+  return (
+    <View className="mt-12 gap-6">
+      {error && <Text className="text-primary text-sm text-center">{error}</Text>}
+
+      <View className="gap-1.5">
+        <Label htmlFor="email" className={labelClassName}>
+          Email
+        </Label>
+        <Input
+          id="email"
+          placeholder="you@example.com"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          className={inputClassName}
+        />
+      </View>
+
+      <View className="gap-1.5">
+        <Label htmlFor="password" className={labelClassName}>
+          Password
+        </Label>
+        <Input
+          id="password"
+          placeholder="••••••••"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+          className={inputClassName}
+        />
+      </View>
+
+      <Button
+        className="w-full bg-primary rounded-sm mt-2"
+        onPress={() => onSubmit(email, password)}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color={colors.onPrimary} />
+        ) : (
+          <Text className="text-on-primary text-xs font-medium uppercase tracking-wider text-center">
+            Sign In
+          </Text>
+        )}
+      </Button>
+
+      <Text className="text-center text-sm text-outline">
+        Don&apos;t have an account?{" "}
+        <Text className="text-primary text-sm font-medium" onPress={onSignUp}>
+          Sign up
+        </Text>
+      </Text>
+    </View>
+  )
+}

--- a/src/components/Auth/SignUpForm.tsx
+++ b/src/components/Auth/SignUpForm.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react"
+import { View, ActivityIndicator } from "react-native"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Text } from "@/components/ui/text"
+import { useAppTheme } from "@/theme/context"
+
+import { inputClassName, labelClassName } from "./authFormStyles"
+
+type SignUpFormProps = {
+  loading: boolean
+  error: string | null
+  fieldErrors: Record<string, string[]>
+  onSubmit: (name: string, email: string, password: string) => void
+  onSignIn: () => void
+}
+
+export function SignUpForm({ loading, error, fieldErrors, onSubmit, onSignIn }: SignUpFormProps) {
+  const { theme } = useAppTheme()
+  const colors = theme.colors
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
+
+  return (
+    <View className="mt-10 gap-5">
+      {error && <Text className="text-primary text-sm text-center">{error}</Text>}
+
+      <View className="gap-1.5">
+        <Label htmlFor="name" className={labelClassName}>
+          Name
+        </Label>
+        <Input
+          id="name"
+          placeholder="Your full name"
+          value={name}
+          onChangeText={setName}
+          className={inputClassName}
+        />
+        {fieldErrors.name?.map((e) => (
+          <Text key={e} className="text-primary text-xs">
+            {e}
+          </Text>
+        ))}
+      </View>
+
+      <View className="gap-1.5">
+        <Label htmlFor="email" className={labelClassName}>
+          Email
+        </Label>
+        <Input
+          id="email"
+          placeholder="you@example.com"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          className={inputClassName}
+        />
+        {fieldErrors.email_address?.map((e) => (
+          <Text key={e} className="text-primary text-xs">
+            {e}
+          </Text>
+        ))}
+      </View>
+
+      <View className="gap-1.5">
+        <Label htmlFor="password" className={labelClassName}>
+          Password
+        </Label>
+        <Input
+          id="password"
+          placeholder="••••••••"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+          className={inputClassName}
+        />
+        {fieldErrors.password?.map((e) => (
+          <Text key={e} className="text-primary text-xs">
+            {e}
+          </Text>
+        ))}
+      </View>
+
+      <View className="gap-1.5">
+        <Label htmlFor="confirm" className={labelClassName}>
+          Confirm Password
+        </Label>
+        <Input
+          id="confirm"
+          placeholder="••••••••"
+          value={confirm}
+          onChangeText={setConfirm}
+          secureTextEntry
+          className={inputClassName}
+        />
+      </View>
+
+      <Button
+        className="w-full bg-primary rounded-sm mt-2"
+        onPress={() => onSubmit(name, email, password)}
+        disabled={loading}
+      >
+        {loading ? (
+          <ActivityIndicator color={colors.onPrimary} />
+        ) : (
+          <Text className="text-on-primary text-xs font-medium uppercase tracking-wider text-center">
+            Create Account
+          </Text>
+        )}
+      </Button>
+
+      <Text className="text-center text-sm text-outline">
+        Already have an account?{" "}
+        <Text className="text-primary text-sm font-medium" onPress={onSignIn}>
+          Sign in
+        </Text>
+      </Text>
+    </View>
+  )
+}

--- a/src/components/Auth/authFormStyles.ts
+++ b/src/components/Auth/authFormStyles.ts
@@ -1,0 +1,4 @@
+export const inputClassName =
+  "bg-surface-container border-outline-variant/50 rounded-sm h-[50px] px-[14px] text-sm text-on-surface"
+
+export const labelClassName = "text-xs uppercase tracking-[0.1em] text-on-surface"

--- a/src/components/ClubsList/ClubCard.tsx
+++ b/src/components/ClubsList/ClubCard.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet, TouchableOpacity } from "react-native"
+
+import { StateBadge } from "@/components/StateBadge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Text } from "@/components/ui/text"
+import type { ClubSummary } from "@/services/api/types"
+
+type ClubCardProps = {
+  club: ClubSummary
+  onPress: (id: number) => void
+}
+
+export function ClubCard({ club, onPress }: ClubCardProps) {
+  const state = club.current_cycle?.state ?? null
+  return (
+    <TouchableOpacity activeOpacity={0.7} onPress={() => onPress(club.id)}>
+      <Card className="mb-3 rounded border-0 bg-surface-container-lowest px-0 shadow-none gap-0">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-lg font-normal text-on-surface" style={styles.titleFont}>
+            {club.name}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="gap-2">
+          {state ? <StateBadge state={state} /> : null}
+          {club.description ? (
+            <Text className="text-sm text-outline leading-relaxed">{club.description}</Text>
+          ) : null}
+        </CardContent>
+      </Card>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  titleFont: {
+    fontFamily: "newsreaderRegular",
+  },
+})

--- a/src/components/ClubsList/EmptyClubsState.tsx
+++ b/src/components/ClubsList/EmptyClubsState.tsx
@@ -1,0 +1,22 @@
+import { StyleSheet, View } from "react-native"
+
+import { Text } from "@/components/ui/text"
+
+export function EmptyClubsState() {
+  return (
+    <View className="items-center px-6 gap-3 mt-16">
+      <Text className="text-xl text-on-surface text-center" style={styles.titleFont}>
+        Your bookshelf is waiting.
+      </Text>
+      <Text className="text-sm text-outline text-center leading-relaxed">
+        Start or join a club to begin your next chapter.
+      </Text>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  titleFont: {
+    fontFamily: "newsreaderRegular",
+  },
+})

--- a/src/screens/ClubsScreen.tsx
+++ b/src/screens/ClubsScreen.tsx
@@ -1,0 +1,82 @@
+import { ActivityIndicator, FlatList, RefreshControl, StyleSheet, View } from "react-native"
+
+import { ClubCard } from "@/components/ClubsList/ClubCard"
+import { EmptyClubsState } from "@/components/ClubsList/EmptyClubsState"
+import { Screen } from "@/components/Screen"
+import { Text } from "@/components/ui/text"
+import type { ClubSummary } from "@/services/api/types"
+import { useAppTheme } from "@/theme/context"
+
+type ClubsScreenProps = {
+  clubs: ClubSummary[]
+  loading: boolean
+  refreshing: boolean
+  error: string | null
+  onClubPress: (id: number) => void
+  onRefresh: () => void
+}
+
+export function ClubsScreen({
+  clubs,
+  loading,
+  refreshing,
+  error,
+  onClubPress,
+  onRefresh,
+}: ClubsScreenProps) {
+  const { theme } = useAppTheme()
+  const colors = theme.colors
+
+  return (
+    <Screen preset="fixed" safeAreaEdges={["top"]} contentContainerStyle={styles.screenContent}>
+      {loading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color={colors.primary} />
+        </View>
+      ) : (
+        <FlatList
+          data={clubs}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={({ item }) => <ClubCard club={item} onPress={onClubPress} />}
+          contentContainerStyle={styles.listContent}
+          ListHeaderComponent={
+            <Text
+              className="text-on-surface mt-12 mb-5 text-[28px] tracking-tight"
+              style={styles.titleFont}
+            >
+              Your Clubs
+            </Text>
+          }
+          ListEmptyComponent={
+            error ? (
+              <Text className="text-sm text-outline text-center mt-8">{error}</Text>
+            ) : (
+              <EmptyClubsState />
+            )
+          }
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.primary}
+            />
+          }
+        />
+      )}
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    flexGrow: 1,
+    paddingBottom: 16,
+    paddingHorizontal: 20,
+  },
+  screenContent: {
+    flex: 1,
+  },
+  titleFont: {
+    fontFamily: "newsreaderRegular",
+  },
+})

--- a/src/screens/SignInScreen.tsx
+++ b/src/screens/SignInScreen.tsx
@@ -1,0 +1,28 @@
+import { StyleSheet } from "react-native"
+
+import { AuthHeader } from "@/components/Auth/AuthHeader"
+import { SignInForm } from "@/components/Auth/SignInForm"
+import { Screen } from "@/components/Screen"
+
+type SignInScreenProps = {
+  loading: boolean
+  error: string | null
+  onSignIn: (email: string, password: string) => void
+  onSignUp: () => void
+}
+
+export function SignInScreen({ loading, error, onSignIn, onSignUp }: SignInScreenProps) {
+  return (
+    <Screen preset="fixed" safeAreaEdges={["top"]} contentContainerStyle={styles.content}>
+      <AuthHeader variant="sign-in" />
+
+      <SignInForm loading={loading} error={error} onSubmit={onSignIn} onSignUp={onSignUp} />
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: 24,
+  },
+})

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -1,0 +1,42 @@
+import { StyleSheet } from "react-native"
+
+import { AuthHeader } from "@/components/Auth/AuthHeader"
+import { SignUpForm } from "@/components/Auth/SignUpForm"
+import { Screen } from "@/components/Screen"
+
+type SignUpScreenProps = {
+  loading: boolean
+  error: string | null
+  fieldErrors: Record<string, string[]>
+  onSignUp: (name: string, email: string, password: string) => void
+  onSignIn: () => void
+}
+
+export function SignUpScreen({
+  loading,
+  error,
+  fieldErrors,
+  onSignUp,
+  onSignIn,
+}: SignUpScreenProps) {
+  return (
+    <Screen preset="scroll" safeAreaEdges={["top"]} contentContainerStyle={styles.content}>
+      <AuthHeader variant="sign-up" />
+
+      <SignUpForm
+        loading={loading}
+        error={error}
+        fieldErrors={fieldErrors}
+        onSubmit={onSignUp}
+        onSignIn={onSignIn}
+      />
+    </Screen>
+  )
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingBottom: 32,
+    paddingHorizontal: 24,
+  },
+})


### PR DESCRIPTION
Extract inline UI and sub-components out of Expo Router route files into a clear two-layer structure:

- Route files (app/) now own only state, data-fetching, and navigation callbacks; all rendering is delegated to a named Screen component
- Screen components (src/screens/) own layout and orchestration for a given route, accepting data and handler props
- Reusable UI pieces are broken into focused components under src/components/: AuthHeader, SignInForm, SignUpForm, ClubCard, EmptyClubsState, and shared authFormStyles
- Auth stack gains a `fade` transition via _layout.tsx

No behaviour changes intended.